### PR TITLE
Message model update.

### DIFF
--- a/Sources/Joint/JointSession.swift
+++ b/Sources/Joint/JointSession.swift
@@ -33,7 +33,7 @@ public final class JointSession: ObservableObject {
         core.$data
             .sink { data in
                 if self.transporting {
-                    let message = Message(source: source, data: data)
+                    let message = Message(for: source, carrying: data)
                     
                     self.transport.publish(message: message)
                     self.outgoing = message

--- a/Sources/Joint/Transport/Data/Message.swift
+++ b/Sources/Joint/Transport/Data/Message.swift
@@ -9,17 +9,17 @@ import Foundation
 
 /// Message description.
 public protocol Payload {
-    var source: String { get }
-    var data: Data { get }
+    var channel: String { get }
+    var payload: Data { get }
 }
 
-/// The source and contents of a message being transported.
+/// Intended recipient and contents of a message being transported.
 public struct Message: Payload {
-    public init(source: String, data: Data) {
-        self.source = source
-        self.data = data
+    public init(for channel: String, carrying payload: Data) {
+        self.channel = channel
+        self.payload = payload
     }
     
-    public var source: String
-    public var data: Data
+    public var channel: String
+    public var payload: Data
 }

--- a/Sources/Joint/Transport/Transport.swift
+++ b/Sources/Joint/Transport/Transport.swift
@@ -41,7 +41,7 @@ public enum TransportStatus {
 }
 
 final class Transport: ObservableObject {
-    @Published var receiving: Message = .init(source: "", data: Data())
+    @Published var receiving: Message = .init(for: "", carrying: Data())
     @Published var error: TransportError = .none
     @Published var status: TransportStatus = .disconnected
     

--- a/Sources/Joint/Transport/Types/MQTT.swift
+++ b/Sources/Joint/Transport/Types/MQTT.swift
@@ -42,9 +42,9 @@ extension Transport {
         }
         
         func publish(message: Message) {
-            session?.publishData(message.data, onTopic: message.source, retain: false, qos: self.qos, publishHandler: { error in
+            session?.publishData(message.payload, onTopic: message.channel, retain: false, qos: self.qos, publishHandler: { error in
                 if let error {
-                    self.error.send(.publishing(message.source, error, .critial))
+                    self.error.send(.publishing(message.channel, error, .critial))
                 }
             })
         }
@@ -107,7 +107,7 @@ extension Transport {
         }
         
         func newMessage(_ session: MQTTSession!, data: Data!, onTopic topic: String!, qos: MQTTQosLevel, retained: Bool, mid: UInt32) {
-            receiving.send(Message(source: topic, data: data))
+            receiving.send(Message(for: topic, carrying: data))
         }
     }
 }


### PR DESCRIPTION
Changing `source` to `channel` and `data` to `payload` for clarity.